### PR TITLE
add coding standard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 Repo lưu lại kinh nghiệm, kiến thức ở Hapo. 
 
 ## Mục lục
-1. Các rule chung
-2. Quy trình làm việc
-3. [Cơ bản về PHP](php.md)
+1. [Coding Standard](coding-standard.md) 
+2. [Cơ bản về PHP](php.md)
 3. [Cơ bản về Laravel](laravel.md) 
 4. [Cơ bản về HTML&CSS](css.md)
 5. [Cơ bản về Javascript](javascript.md) 

--- a/coding-standard.md
+++ b/coding-standard.md
@@ -1,0 +1,20 @@
+# Coding Standard at Haposoft 
+
+1. [Git & Git Flow](coding-standard/git.md)
+
+## HTML&CSS
+6. [HTML&CSS coding convention](coding-standard/html-css.md)
+7. [Twitter Bootstrap](coding-standard/twitter-bootstrap.md)
+
+## PHP 
+2. [PHP coding convention](coding-standard/php.md)
+3. [Laravel coding convention](coding-standard/laravel.md)
+
+## Ruby 
+
+4. [Ruby coding convention](coding-standard/ruby.md)
+5. [Ruby on Rails coding convention](coding-standard/ruby-on-rails.md)
+
+## Javascript & Nodejs
+
+1. [Javascript coding convention](coding-standard/javascript.md)

--- a/coding-standard/git.md
+++ b/coding-standard/git.md
@@ -1,0 +1,1 @@
+# Git convention

--- a/coding-standard/html-css.md
+++ b/coding-standard/html-css.md
@@ -1,0 +1,1 @@
+# HTML&CSS coding convention

--- a/coding-standard/javascript.md
+++ b/coding-standard/javascript.md
@@ -1,0 +1,1 @@
+# Javascript coding convention

--- a/coding-standard/laravel.md
+++ b/coding-standard/laravel.md
@@ -1,0 +1,1 @@
+# Laravel coding convention

--- a/coding-standard/php.md
+++ b/coding-standard/php.md
@@ -1,0 +1,1 @@
+# PHP coding convention

--- a/coding-standard/ruby-on-rails.md
+++ b/coding-standard/ruby-on-rails.md
@@ -1,0 +1,1 @@
+# Ruby on Rails coding convention

--- a/coding-standard/ruby.md
+++ b/coding-standard/ruby.md
@@ -1,0 +1,1 @@
+# Ruby coding convention

--- a/coding-standard/twitter-bootstrap.md
+++ b/coding-standard/twitter-bootstrap.md
@@ -1,0 +1,1 @@
+# Twitter Boostrap coding convention


### PR DESCRIPTION
Add thêm các file cần hoàn thành để viết coding standard cho Haposoft. 

Các file liên quan tới coding standard sẽ được nằm trong folder coding-standard. 

Sau khi merge, các thành viên sẽ chịu trách nhiệm các phần coding-standard tương ứng, đưa ra đề xuất bằng cách sửa các file và gửi pull-request để toàn bộ các member liên quan review.
